### PR TITLE
Filter the output json for null values

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -276,7 +276,7 @@ class Json extends MergeValue
      */
     public function serializeValue($value, $model)
     {   
-        return $this->isJsonCastable($model) ? $value : json_encode($value);  
+        return array_filter($this->isJsonCastable($model) ? $value : json_encode($value));  
     }
 
     /**


### PR DESCRIPTION
If you save the json field, in your current version, `null` values are stored as well. To make the json more readable and save db space, just filter the data.

Instead of (for example) 

```json
{
    "name": "My Name",
    "surname": null,
    "lastname": null,
    "email": "office@example.com",
    "birthdate": null,
    "gender": null
}
```

you will get

```json
{
    "name": "My Name",
    "email": "office@example.com",
}
```